### PR TITLE
Update imagej_roi_converter.py

### DIFF
--- a/imagej_roi_converter.py
+++ b/imagej_roi_converter.py
@@ -14,16 +14,16 @@ rm = RM.getRoiManager()
 
 imp = IJ.getImage()
 
-with open(file_name, 'r') as textfile:
-	for line in textfile:
-		xy = map(int, line.rstrip().split(','))
-		X = xy[::2]
-		Y = xy[1::2]
-		imp.setRoi(PolygonRoi(X, Y, Roi.POLYGON));
-		#IJ.run(imp, "Convex Hull", "")
-		roi = imp.getRoi()
-		print roi
-		rm.addRoi(roi)
+textfile = open(file_name, 'r')
+for line in textfile:
+	xy = map(int, line.rstrip().split(','))
+	X = xy[::2]
+	Y = xy[1::2]
+	imp.setRoi(PolygonRoi(X, Y, Roi.POLYGON));
+	#IJ.run(imp, "Convex Hull", "")
+	roi = imp.getRoi()
+	print roi
+	rm.addRoi(roi)
   
 rm.runCommand("Associate", "true")	 
 rm.runCommand("Show All with labels")


### PR DESCRIPTION
ImageJ only supports Jython 2.5.3 or 2.5.4. Changing line 17 from "with open(file_name, 'r') as textfile:" to the old styled open statement.